### PR TITLE
Fix patches

### DIFF
--- a/patches/proxmox.patch
+++ b/patches/proxmox.patch
@@ -9,13 +9,3 @@
  KVNAME=${KERNEL_VER}${EXTRAVERSION}
  PACKAGE=pve-kernel-${KVNAME}
  HDRPACKAGE=pve-headers-${KVNAME}
---- a/debian/scripts/find-firmware.pl
-+++ b/debian/scripts/find-firmware.pl
-@@ -8,7 +8,7 @@
-
- die "no such directory" if ! -d $dir;
-
--die "strange directory name: $dir" if $dir !~ m|^(.*/)?(5.\d.\d+\-\d+\-pve)(/+)?$|;
-+#die "strange directory name: $dir" if $dir !~ m|^(.*/)?(5.\d.\d+\-\d+\-pve)(/+)?$|;
-
- my $apiver = $2;

--- a/patches/proxmox7.patch
+++ b/patches/proxmox7.patch
@@ -9,14 +9,3 @@
  KVNAME=${KERNEL_VER}${EXTRAVERSION}
  PACKAGE=pve-kernel-${KVNAME}
  HDRPACKAGE=pve-headers-${KVNAME}
---- a/debian/scripts/find-firmware.pl
-+++ b/debian/scripts/find-firmware.pl
-@@ -8,7 +8,7 @@
-
- die "no such directory" if ! -d $dir;
-
--die "strange directory name: $dir" if $dir !~ m|^(.*/)?(\d+.\d+.\d+\-\d+\-pve)(/+)?$|;
-+#die "strange directory name: $dir" if $dir !~ m|^(.*/)?(\d+.\d+.\d+\-\d+\-pve)(/+)?$|;
-
-
- my $apiver = $2;


### PR DESCRIPTION
Looks like the root of the issue (broken builds) is the change here: https://git.proxmox.com/?p=pve-kernel.git;a=blobdiff;f=debian/scripts/find-firmware.pl;h=17cdaf817e64368e79a706e8e904a407f87a5ba4;hp=4d72d4e80f213249d7c9bdc0d510b7c44c9cbb63;hb=35fd42877fcc7c4d3ecb4c9199cb526573b64522;hpb=81dd1548115564e25eee8d0df1466231399280f8

The adjustment means the existing patch file is no longer valid. As the line to be patched has gone I will remove this section of the patch out as it is no longer needed.