### PR TITLE
fix python3-config not found error during building pve-kernel-5.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt -y update
 RUN apt -y install git nano screen patch fakeroot build-essential devscripts libncurses5 libncurses5-dev libssl-dev bc \
  flex bison libelf-dev libaudit-dev libgtk2.0-dev libperl-dev asciidoc xmlto gnupg gnupg2 rsync lintian debhelper \
  libdw-dev libnuma-dev libslang2-dev sphinx-common asciidoc-base automake cpio dh-python file gcc kmod libiberty-dev \
- libpve-common-perl libtool perl-modules python3-minimal sed tar zlib1g-dev lz4 curl zstd dwarves 
+ libpve-common-perl libtool perl-modules python3-minimal python3-dev sed tar zlib1g-dev lz4 curl zstd dwarves 
 
 #Need pahole 1.16 or above
 RUN TEMP_DEB="$(mktemp)" && \


### PR DESCRIPTION
Hi, I am trying to build pve kernel version 5.15, so I have modified your script changing the branch to  `pve-kernel-5.15` which will lead to an error *python3-config not found*. It's a missing package in the builder container, this should fix that. Btw, I have tried 5.13 and the latest 5.19, 5.19 seems fine.